### PR TITLE
Scroll - Fixing buggy scroll behaviour on less than min-zoom.

### DIFF
--- a/library/src/main/java/com/alexvasilkov/gestures/GestureController.java
+++ b/library/src/main/java/com/alexvasilkov/gestures/GestureController.java
@@ -426,11 +426,8 @@ public class GestureController implements View.OnTouchListener {
         }
 
         if (isScrollDetected) {
-            // Only scrolling if we are not zoomed less than min zoom
-            if (State.compare(state.getZoom(), stateController.getEffectiveMinZoom()) >= 0) {
-                state.translateBy(-dx, -dy);
-                isStateChangedDuringTouch = true;
-            }
+            state.translateBy(-dx, -dy);
+            isStateChangedDuringTouch = true;
         }
 
         return isScrollDetected;

--- a/sample/src/main/java/com/alexvasilkov/gestures/sample/activities/PhotoCropActivity.java
+++ b/sample/src/main/java/com/alexvasilkov/gestures/sample/activities/PhotoCropActivity.java
@@ -72,6 +72,7 @@ public class PhotoCropActivity extends BaseActivity {
         GestureController controller = imageView.getController();
 
         // Setting cropping area
+        controller.getSettings().setRestrictBounds(false);
         controller.getSettings().setMovementArea(finderWidth, finderHeight);
 
         if (animate) {


### PR DESCRIPTION
This pull request fixes issue #41 .

To reproduce:
 - Go to "Advanced demo"
 - Open an image
 - Press the "rotate & crop" icon on the top right
 - Make the image about half of the size of the white rectangle
 - See that panning, rotating and zooming still works properly