### PR TITLE
Replaced support-v4 dependency with smaller subset (support-core-ui)

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-    compileOnly 'com.android.support:support-v4:27.0.2'
+    compileOnly 'com.android.support:support-core-ui:27.0.2'
     compileOnly 'com.android.support:recyclerview-v7:27.0.2'
 }
 


### PR DESCRIPTION
I think it would be a good idea to follow [Ian Lake's recommendation](https://twitter.com/ianhlake/status/923611872271548417) and replaced support-v4 dependency with smaller subset (support-compat).

Here is a dependencies tree when `support-v4` is used (./gradlew library:dependencies):

    +--- com.android.support:support-v4:27.0.2
    |    +--- com.android.support:support-compat:27.0.2
    |    |    +--- com.android.support:support-annotations:27.0.2
    |    |    \--- android.arch.lifecycle:runtime:1.0.3
    |    |         +--- android.arch.lifecycle:common:1.0.3
    |    |         \--- android.arch.core:common:1.0.0
    |    +--- com.android.support:support-media-compat:27.0.2
    |    |    +--- com.android.support:support-annotations:27.0.2
    |    |    \--- com.android.support:support-compat:27.0.2 (*)
    |    +--- com.android.support:support-core-utils:27.0.2
    |    |    +--- com.android.support:support-annotations:27.0.2
    |    |    \--- com.android.support:support-compat:27.0.2 (*)
    |    +--- com.android.support:support-core-ui:27.0.2
    |    |    +--- com.android.support:support-annotations:27.0.2
    |    |    \--- com.android.support:support-compat:27.0.2 (*)
    |    \--- com.android.support:support-fragment:27.0.2
    |         +--- com.android.support:support-compat:27.0.2 (*)
    |         +--- com.android.support:support-core-ui:27.0.2 (*)
    |         +--- com.android.support:support-core-utils:27.0.2 (*)
    |         \--- com.android.support:support-annotations:27.0.2
    \--- com.android.support:recyclerview-v7:27.0.2
         +--- com.android.support:support-annotations:27.0.2
         +--- com.android.support:support-compat:27.0.2 (*)
         \--- com.android.support:support-core-ui:27.0.2 (*)
     +--- com.android.support:support-compat:27.0.2 (*)
     \--- com.android.support:support-core-ui:27.0.2 (*)

When `support-core-ui` ([it constains i.a. ViewPager](https://developer.android.com/topic/libraries/support-library/packages.html#v4-core-ui) - GestureViews depends on it) is used instead:

    +--- com.android.support:support-core-ui:27.0.2
    |    +--- com.android.support:support-annotations:27.0.2
    |    \--- com.android.support:support-compat:27.0.2
    |         +--- com.android.support:support-annotations:27.0.2
    |         \--- android.arch.lifecycle:runtime:1.0.3
    |              +--- android.arch.lifecycle:common:1.0.3
    |              \--- android.arch.core:common:1.0.0
    \--- com.android.support:recyclerview-v7:27.0.2
         +--- com.android.support:support-annotations:27.0.2
         +--- com.android.support:support-compat:27.0.2 (*)
         \--- com.android.support:support-core-ui:27.0.2 (*)

As you can see unused dependencies like support-media-compat and support-fragment can be easily dropped.

`recyclerview-v7` depends on support-core-ui already, but I think it's good idea to include `support-core-ui` anyway, so ViewPager won't be provided via transitive dependency